### PR TITLE
Add the `[global]` field to set global variables in the generated theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Style Options:
 - `r`: reverse
 - `n`: nocombine
 
+You can also generate global variables for the colorscheme, which might be needed for some plugins.
+
+```toml
+[global]
+variable = "<content>"
+```
+
+Where `"<content>"` accepts any string.
+
 TODO:
 
 - support transparent background (this could get tricky with other plugins, considering bg:optional, if you put that then setting the transparent flag will set it to none) 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,4 +6,15 @@ use std::path::PathBuf;
 pub struct ColorgenArgs {
     /// The filename for your colorscheme
     pub filename: PathBuf,
+
+    /// Write into a single file instead of writing a whole module
+    #[arg(short, long, default_value_t = false)]
+    pub single_file: bool,
+
+    /// File/Directory to write the theme to.
+    ///
+    /// If used together with `--single-file` it will either write directly to the file, or if
+    /// `--output` is a directory it will write into this directory under `<theme-name>.lua`.
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
 }

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -9,7 +9,7 @@ pub struct InitLua<'a> {
 impl<'a> Display for InitLua<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let name = &self.name;
-        let background = &self.background;
+        let background = self.background;
 
         writeln!(
             f,
@@ -17,20 +17,43 @@ impl<'a> Display for InitLua<'a> {
 local theme = require('{name}.theme')
 
 M.setup = function()
-  vim.cmd('hi clear')
-
-  vim.o.background = '{background}'
-  if vim.fn.exists('syntax_on') then
-    vim.cmd('syntax reset')
-  end
-
-  vim.o.termguicolors = true
-  vim.g.colors_name = '{name}'
+{setup}
 
   theme.set_highlights()
 end
 
-return M"#
+return M"#,
+            setup = InitSetup {
+                name,
+                background,
+                indent: "  "
+            }
+        )
+    }
+}
+
+pub struct InitSetup<'a> {
+    pub name: &'a str,
+    pub background: Background,
+    pub indent: &'a str,
+}
+
+impl Display for InitSetup<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#"{indent}vim.cmd('hi clear')
+
+{indent}vim.o.background = '{background}'
+{indent}if vim.fn.exists('syntax_on') then
+{indent}  vim.cmd('syntax reset')
+{indent}end
+
+{indent}vim.o.termguicolors = true
+{indent}vim.g.colors_name = '{name}'"#,
+            indent = self.indent,
+            name = self.name,
+            background = self.background
         )
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,0 +1,16 @@
+use linked_hash_map::LinkedHashMap;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Global(LinkedHashMap<String, String>);
+
+impl Display for Global {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "-- set global variables")?;
+        for (key, value) in &self.0 {
+            writeln!(f, "vim.g.{key} = \"{value}\"")?;
+        }
+        Ok(())
+    }
+}

--- a/src/information.rs
+++ b/src/information.rs
@@ -1,6 +1,5 @@
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Information {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl SingleFile<'_> {
 impl Display for SingleFile<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if let Some(global) = &self.global {
-            write!(f, "{}", global)?;
+            writeln!(f, "{}", global)?;
         }
         write!(f, "{}\n\n", self.init_setup)?;
         write!(f, "local c = {{")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-use crate::{information::Information, palette::Palette, sections::Sections};
-use formatters::{InitLua, InitSetup, VimColorsFile};
-use macros::write_file;
-use palette::InnerPalette;
-use sections::{SectionsFormatter, ThemeHighlights};
+use crate::{
+    formatters::{InitLua, InitSetup, VimColorsFile},
+    information::Information,
+    macros::write_file,
+    palette::{InnerPalette, Palette},
+    sections::{Sections, SectionsFormatter, ThemeHighlights},
+};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display, Formatter},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 use crate::{information::Information, palette::Palette, sections::Sections};
-use formatters::{InitLua, VimColorsFile};
+use formatters::{InitLua, InitSetup, VimColorsFile};
 use macros::write_file;
-use sections::SectionsFormatter;
+use palette::InnerPalette;
+use sections::{SectionsFormatter, ThemeHighlights};
 use serde::{Deserialize, Serialize};
 use std::{
-    fs, io,
+    fmt::{self, Display, Formatter},
+    fs::{self, File},
+    io::{self, BufWriter, Write},
     path::{Path, PathBuf},
 };
 
@@ -24,27 +27,21 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn generate(&self, base_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn generate(&self, base_path: &Path) -> io::Result<()> {
         let name = Path::new(&self.information.name);
         self.setup_directories(base_path)?;
 
-        write_file!(
-            [base_path, name, "lua", name, "init.lua"],
-            self.generate_init(),
-        )?;
+        write_file!([base_path, "lua", name, "init.lua"], self.generate_init(),)?;
 
         let init_lua = name.with_extension("lua");
         write_file!(
-            [base_path, name, "colors", init_lua],
+            [base_path, "colors", init_lua],
             self.generate_vim_colors_file(),
         )?;
 
-        write_file!([base_path, name, "lua", name, "palette.lua"], &self.palette,)?;
+        write_file!([base_path, "lua", name, "palette.lua"], &self.palette,)?;
 
-        write_file!(
-            [base_path, name, "lua", name, "theme.lua"],
-            self.generate_theme(),
-        )?;
+        write_file!([base_path, "lua", name, "theme.lua"], self.generate_theme(),)?;
 
         Ok(())
     }
@@ -52,15 +49,11 @@ impl Template {
     pub fn setup_directories(&self, base_path: &Path) -> io::Result<()> {
         let name = Path::new(&self.information.name);
         fs::create_dir_all(
-            [base_path, name, Path::new("lua"), name]
+            [base_path, Path::new("lua"), name]
                 .iter()
                 .collect::<PathBuf>(),
         )?;
-        fs::create_dir_all(
-            [base_path, name, Path::new("colors")]
-                .iter()
-                .collect::<PathBuf>(),
-        )?;
+        fs::create_dir_all([base_path, Path::new("colors")].iter().collect::<PathBuf>())?;
         Ok(())
     }
 
@@ -82,5 +75,49 @@ impl Template {
             theme_name: &self.information.name,
             sections: &self.sections,
         }
+    }
+
+    pub fn generate_single_file(&self) -> SingleFile {
+        SingleFile {
+            init_setup: InitSetup {
+                name: &self.information.name,
+                background: self.information.background,
+                indent: "",
+            },
+            palette: InnerPalette {
+                colors: &self.palette.0,
+                indent: "  ",
+            },
+            theme: ThemeHighlights {
+                theme_name: &self.information.name,
+                sections: &self.sections,
+                indent: "",
+            },
+        }
+    }
+}
+
+pub struct SingleFile<'a> {
+    pub init_setup: InitSetup<'a>,
+    pub palette: InnerPalette<'a>,
+    pub theme: ThemeHighlights<'a>,
+}
+
+impl SingleFile<'_> {
+    pub fn write_to_file(&self, path: &Path) -> io::Result<()> {
+        let mut file = BufWriter::new(File::create(path)?);
+        file.write_fmt(format_args!("{}", self))?;
+        Ok(())
+    }
+}
+
+impl Display for SingleFile<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}\n\n", self.init_setup)?;
+        write!(f, "local c = {{")?;
+        write!(f, "{}\n\n", self.palette)?;
+        write!(f, "local hl = vim.api.nvim_set_hl")?;
+        write!(f, "{}", self.theme)?;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::{
     formatters::{InitLua, InitSetup, VimColorsFile},
+    global::Global,
     information::Information,
     macros::write_file,
     palette::{InnerPalette, Palette},
@@ -15,6 +16,7 @@ use std::{
 
 pub mod cli;
 pub mod formatters;
+pub mod global;
 pub mod information;
 pub(crate) mod macros;
 pub mod palette;
@@ -24,6 +26,7 @@ pub mod sections;
 pub struct Template {
     pub information: Information,
     pub palette: Palette,
+    pub global: Option<Global>,
     #[serde(flatten)]
     pub sections: Sections,
 }
@@ -90,6 +93,7 @@ impl Template {
                 colors: &self.palette.0,
                 indent: "  ",
             },
+            global: self.global.as_ref(),
             theme: ThemeHighlights {
                 theme_name: &self.information.name,
                 sections: &self.sections,
@@ -103,6 +107,7 @@ pub struct SingleFile<'a> {
     pub init_setup: InitSetup<'a>,
     pub palette: InnerPalette<'a>,
     pub theme: ThemeHighlights<'a>,
+    pub global: Option<&'a Global>,
 }
 
 impl SingleFile<'_> {
@@ -115,6 +120,9 @@ impl SingleFile<'_> {
 
 impl Display for SingleFile<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if let Some(global) = &self.global {
+            write!(f, "{}", global)?;
+        }
         write!(f, "{}\n\n", self.init_setup)?;
         write!(f, "local c = {{")?;
         write!(f, "{}\n\n", self.palette)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,33 @@ fn main() {
 }
 
 fn inner() -> Result<(), Box<dyn error::Error>> {
-    let template: Template = toml::from_str(&read_to_string(ColorgenArgs::parse().filename)?)?;
+    let args = ColorgenArgs::parse();
+    let template: Template = toml::from_str(&read_to_string(&args.filename)?)?;
 
-    template.generate(Path::new(""))?;
+    match args.single_file {
+        false => {
+            template.generate(
+                &args
+                    .output
+                    .as_deref()
+                    .unwrap_or(Path::new(&template.information.name)),
+            )?;
+        }
+        true => {
+            let path = match args.output {
+                Some(mut path) => {
+                    if path.is_dir() {
+                        path.push(&template.information.name);
+                        path.as_mut_os_string().push(".lua");
+                    }
+                    path
+                }
+                None => Path::new(&template.information.name).with_extension("lua"),
+            };
+
+            template.generate_single_file().write_to_file(&path)?;
+        }
+    }
+
     Ok(())
 }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -11,10 +11,28 @@ pub struct Palette(pub LinkedHashMap<String, RgbColor>);
 
 impl Display for Palette {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "local colors = {{")?;
-        for (key, val) in &self.0 {
-            write!(f, "\n  {key} = \"{val}\",")?;
+        write!(
+            f,
+            "local colors = {{{palette}\n\nreturn colors",
+            palette = InnerPalette {
+                colors: &self.0,
+                indent: "  "
+            }
+        )
+    }
+}
+
+pub struct InnerPalette<'a> {
+    pub colors: &'a LinkedHashMap<String, RgbColor>,
+    pub indent: &'a str,
+}
+
+impl Display for InnerPalette<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for (key, val) in self.colors {
+            write!(f, "\n{indent}{key} = \"{val}\",", indent = self.indent)?;
         }
-        write!(f, "\n}}\n\nreturn colors")
+        write!(f, "\n}}")?;
+        Ok(())
     }
 }

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -83,13 +83,39 @@ theme.set_highlights = function()",
             theme_name = self.theme_name
         )?;
 
+        write!(
+            f,
+            "{}",
+            ThemeHighlights {
+                theme_name: self.theme_name,
+                sections: self.sections,
+                indent: "  "
+            }
+        )?;
+
+        write!(f, "\n\nend\n\nreturn theme")
+    }
+}
+
+pub struct ThemeHighlights<'a> {
+    pub theme_name: &'a str,
+    pub sections: &'a Sections,
+    pub indent: &'a str,
+}
+
+impl Display for ThemeHighlights<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for (table_name, section) in &self.sections.0 {
-            write!(f, "\n\n  -- {table_name}")?;
+            write!(f, "\n\n{indent}-- {table_name}", indent = self.indent)?;
             for (hl_group, color_spec) in &section.0 {
-                write!(f, "\n  hl(0, \"{hl_group}\", {color_spec})")?;
+                write!(
+                    f,
+                    "\n{indent}hl(0, \"{hl_group}\", {color_spec})",
+                    indent = self.indent
+                )?;
             }
         }
 
-        write!(f, "\n\nend\n\nreturn theme")
+        Ok(())
     }
 }

--- a/src/sections/color_spec.rs
+++ b/src/sections/color_spec.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
-
 use self::parser::Color;
 use bitflags::bitflags;
+use std::fmt::Display;
 
 pub mod parser;
 


### PR DESCRIPTION
I needed this to properly port [base16-vim](https://github.com/chriskempson/base16-vim) to `colorgen-nvim`.

This PR depends on #13 which should be merged first.
(Though technically merging this one and closing the other one would work too I guess.)
